### PR TITLE
要望内容フォームが埋まるまでチャットを繰り返す様にした

### DIFF
--- a/app/domain/chat.py
+++ b/app/domain/chat.py
@@ -1,7 +1,7 @@
 """チャットドメインモデル"""
 
-from typing import List, Literal
-from dataclasses import dataclass
+from typing import List, Literal, Optional
+from dataclasses import dataclass, field
 
 
 @dataclass
@@ -20,9 +20,41 @@ class Message:
 
 
 @dataclass
+class Form:
+    """問い合わせフォーム"""
+    title: Optional[str] = None  # 例: "家の近くに落書き"
+    category: Optional[Literal["対応依頼", "質問", "賞賛"]] = None
+    description: Optional[str] = None  # 詳細説明
+    place: Optional[str] = None  # 場所名（例: "大田区大森町"）
+    
+    def is_complete(self) -> bool:
+        """フォームが完成しているかどうか"""
+        return (
+            self.title is not None and
+            self.category is not None and
+            self.description is not None and
+            self.place is not None
+        )
+    
+    def get_missing_fields(self) -> List[str]:
+        """未入力のフィールドリストを取得"""
+        missing = []
+        if not self.title:
+            missing.append("title")
+        if not self.category:
+            missing.append("category")
+        if not self.description:
+            missing.append("description")
+        if not self.place:
+            missing.append("place")
+        return missing
+
+
+@dataclass
 class Chat:
     """チャットドメインモデル"""
     messages: List[Message]
+    form: Form = field(default_factory=Form)
     
     def add_message(self, message: Message) -> None:
         """メッセージを追加"""

--- a/app/router.py
+++ b/app/router.py
@@ -26,10 +26,16 @@ async def chat_completion(request: ChatRequest):
     チャット形式での会話エンドポイント
     
     会話履歴を考慮してBedrockが返答を生成します。
+    フォーム機能により、段階的に要望情報を収集します。
     roleは'user'（ユーザー）または'assistant'（AI）を指定してください。
     """
     llm_client = BedrockChatLLMClient()
     # 依存性注入：インフラ層をアプリケーションサービスに注入
     chat_service = LLMChatService(llm_client)
-    result = await chat_service.invoke(request.mail_address, request.messages, request.schema)
+    result = await chat_service.invoke(
+        request.mail_address, 
+        request.messages, 
+        request.form,
+        request.schema
+    )
     return result

--- a/app/services/llm_chat_service.py
+++ b/app/services/llm_chat_service.py
@@ -7,9 +7,9 @@ from typing import List, Dict, Any, Optional, Tuple
 from geopy.geocoders import Nominatim
 
 from app.infrastructure.opinions_table import OpinionsTable
-from app.domain.chat import Chat, Message
+from app.domain.chat import Chat, Message, Form
 from app.services.gateways.chat_llm_client import ChatLLMClient
-from app.spec import ChatMessageDto
+from app.spec import ChatMessageDto, FormDto
 
 
 class LLMChatService:
@@ -18,23 +18,30 @@ class LLMChatService:
     def __init__(self, llm_client: ChatLLMClient):
         self._llm_client = llm_client
         self._opinions_table = OpinionsTable()
-        self._first_prompt = f"""あなたは住民から地域への要望作成を支援するアシスタントです。以下の手順でユーザーの「要望」と要望のある「場所」を聞き出してください。
-1. ユーザー要望の内容を聞き、要望のある場所が不明である場合、場所（最低限、市区町村）を尋ねます。
-2. 不足があれば簡潔に一つずつ補足質問します（同時に複数質問しない）。
-3. 「要望」「場所」が明確になったら、以下のように質問します。
-  - "ありがとうございます。ご要望は以下の通りでよろしいでしょうか？\n要望：<ユーザーの要望>\n場所：<ユーザーの指定した場所>"
-4. ユーザーが間違いない、と回答したら以下の通りに返答してください
-  - "ありがとうございます。要望を送信しました。"
-  - JSON形式の文字列を付け加えてください。
-    - {{"opinion": "XXXXXXX", "place": "YYYYYY"}}
-    - ただし、place は Python の geopy の Nominatim で使用します。
+        self._first_prompt = f"""あなたは住民から地域への要望作成を支援するアシスタントです。以下の手順でユーザーから必要な情報を聞き出してください。
+
+必要な情報：
+- title: 要望のタイトル
+- category: "対応依頼"、"質問"、"賞賛"、 "雑談(それ以外)"のいずれか
+- description: 要望の詳細説明
+- place: 場所（都道府県・市区町村レベルで十分。詳細な住所は不要）
+
+重要な指示：
+1. ユーザーの発言から既に情報を抽出できる場合は、追加質問せずにフォームを更新してください
+2. place は「東京都中央区」「大阪府大阪市」レベルで十分です。具体的な住所や番地は求めないでください
+3. 未入力の項目のみ簡潔に質問してください（同時に複数質問しない）
+4. 全ての情報が揃ったら、確認のため内容をまとめて提示してください
+5. ユーザーが確認したら「ありがとうございます。要望を送信しました。」と返答してください
+
+会話を通じて、フォームの各項目を段階的に埋めていってください。
 """
 
     async def invoke(
         self,
         mail_address: str,
         messages: List[ChatMessageDto],
-        schema: Optional[Dict[str, Any]]
+        form_dto: Optional[FormDto] = None,
+        schema: Optional[Dict[str, Any]] = None
     ) -> Dict[str, Any]:
         """ユーザー入力を受け取り、LLM から応答を生成して返す"""
         if not messages:
@@ -42,37 +49,166 @@ class LLMChatService:
 
         try:
             # ドメインオブジェクトに変換
-            chat = self._create_chat(messages)
-            # AIチャット
-            generated = await self._llm_client.chat(chat.messages, schema=schema)
+            chat = self._create_chat(messages, form_dto)
+            
+            # フォーム機能用のstructured outputスキーマを作成
+            form_schema = self._create_form_schema()
+            
+            # AIチャット（常にフォーム機能用のschemaを使用）
+            generated = await self._llm_client.chat(chat.messages, schema=form_schema)
 
             if isinstance(generated, dict):
-                json_pattern = r"\{\"opinion\": \".*\", \"place\": \".*\"\}"
-                json_string = re.search(json_pattern, generated["answer"])
-
-                # 「場所」と「要望」のJSONが取得できた場合、opinions テーブルに追加
-                if json_string:
-                    json_data = json.loads(json_string.group(0))
-                    id = str(uuid.uuid4())
-                    opinion = json_data["opinion"]
-                    latitude, longitude = self._get_location(json_data["place"])
-                    self._opinions_table.put_opinion(id, mail_address, opinion, latitude, longitude)
-
-                    # JSON部分は削除
-                    generated["answer"] = re.sub(json_pattern, "", generated["answer"])
-
-                return {"success": True, "generated_json": generated}
+                # フォーム情報を更新
+                updated_form = self._update_form_from_response(chat.form, generated)
+                form_complete = updated_form.is_complete()
+                
+                # フォーム完成時の処理
+                if form_complete:
+                    await self._handle_completed_form(mail_address, updated_form)
+                
+                return {
+                    "success": True,
+                    "generated_json": generated,
+                    "form": self._form_to_dto(updated_form),
+                    "form_complete": form_complete
+                }
             else:
-                return {"success": True, "generated_text": generated}
+                # 文字列が返された場合（structured outputが失敗した場合）
+                # 現在のフォーム状態をそのまま返す
+                return {
+                    "success": True,
+                    "generated_text": generated,
+                    "form": self._form_to_dto(chat.form),
+                    "form_complete": chat.form.is_complete()
+                }
 
         except Exception as e:
             return {"success": False, "error": str(e)}
 
-    def _create_chat(self, dtos: List[ChatMessageDto]) -> Chat:
+    def _create_chat(self, dtos: List[ChatMessageDto], form_dto: Optional[FormDto] = None) -> Chat:
         """メッセージリストから Chat ドメインオブジェクトを作成"""
         messages = [Message(role=d.role, content=d.content) for d in dtos]
-        messages.insert(0, Message(role="user", content=self._first_prompt))
-        return Chat(messages)
+        
+        # フォーム状態をプロンプトに含める
+        form_prompt = self._create_form_prompt(form_dto)
+        messages.insert(0, Message(role="user", content=self._first_prompt + form_prompt))
+        
+        # フォームオブジェクトを作成
+        form = self._dto_to_form(form_dto) if form_dto else Form()
+        
+        return Chat(messages=messages, form=form)
+    
+    def _create_form_prompt(self, form_dto: Optional[FormDto]) -> str:
+        """現在のフォーム状態をプロンプトに追加"""
+        if not form_dto:
+            return "\n\n現在のフォーム状態: 空（全て未入力）"
+        
+        form_status = "\n\n現在のフォーム状態:"
+        form_status += f"\n- title: {form_dto.title or '未入力'}"
+        form_status += f"\n- category: {form_dto.category or '未入力'}"
+        form_status += f"\n- description: {form_dto.description or '未入力'}"
+        form_status += f"\n- place: {form_dto.place or '未入力'}"
+        
+        return form_status
+    
+    def _create_form_schema(self) -> Dict[str, Any]:
+        """フォーム機能用のstructured outputスキーマを作成"""
+        return {
+            "type": "object",
+            "properties": {
+                "answer": {
+                    "type": "string",
+                    "description": "AIの会話応答（追加質問など）"
+                },
+                "form": {
+                    "type": "object",
+                    "properties": {
+                        "title": {
+                            "type": ["string", "null"],
+                            "description": "タイトル（未入力の場合はnull）"
+                        },
+                        "category": {
+                            "type": ["string", "null"],
+                            "enum": ["対応依頼", "質問", "賞賛", None],
+                            "description": "カテゴリ（未入力の場合はnull）"
+                        },
+                        "description": {
+                            "type": ["string", "null"],
+                            "description": "詳細説明（未入力の場合はnull）"
+                        },
+                        "place": {
+                            "type": ["string", "null"],
+                            "description": "場所（都道府県レベル、未入力の場合はnull）"
+                        }
+                    },
+                    "required": ["title", "category", "description", "place"],
+                    "additionalProperties": False,
+                    "description": "現在の会話から抽出・更新されたフォーム情報。必ずオブジェクト形式で返すこと。"
+                },
+                "form_complete": {
+                    "type": "boolean",
+                    "description": "フォームが完成したかどうか"
+                }
+            },
+            "required": ["answer", "form", "form_complete"],
+            "additionalProperties": False
+        }
+    
+    def _dto_to_form(self, form_dto: FormDto) -> Form:
+        """FormDtoをFormドメインオブジェクトに変換"""
+        return Form(
+            title=form_dto.title,
+            category=form_dto.category,
+            description=form_dto.description,
+            place=form_dto.place
+        )
+    
+    def _form_to_dto(self, form: Form) -> FormDto:
+        """FormドメインオブジェクトをFormDtoに変換"""
+        return FormDto(
+            title=form.title,
+            category=form.category,
+            description=form.description,
+            place=form.place
+        )
+    
+    def _update_form_from_response(self, current_form: Form, response: Dict[str, Any]) -> Form:
+        """LLMの応答からフォームを更新"""
+        if not isinstance(response, dict):
+            return current_form
+            
+        form_data = response.get("form", {})
+        
+        # 文字列の場合はJSONパースを試行
+        if isinstance(form_data, str):
+            try:
+                form_data = json.loads(form_data)
+                print('JSON文字列をパースしました')
+            except json.JSONDecodeError:
+                print('JSON文字列のパースに失敗')
+                return current_form
+        
+        if not isinstance(form_data, dict):
+            print('formが辞書でも文字列でもない')
+            return current_form
+        
+        return Form(
+            title=form_data.get("title") or current_form.title,
+            category=form_data.get("category") or current_form.category,
+            description=form_data.get("description") or current_form.description,
+            place=form_data.get("place") or current_form.place
+        )
+    
+    async def _handle_completed_form(self, mail_address: str, form: Form) -> None:
+        """完成したフォームの処理"""
+        if form.place:
+            try:
+                id = str(uuid.uuid4())
+                latitude, longitude = self._get_location(form.place)
+                self._opinions_table.put_opinion(id, mail_address, form.description or "", latitude, longitude)
+            except Exception as e:
+                # ログ出力など
+                pass
     
     def _get_location(self, place: str) -> Tuple[float, float]:
         """場所から緯度経度を取得"""

--- a/app/spec.py
+++ b/app/spec.py
@@ -21,6 +21,14 @@ class ChatMessageDto(BaseModel):
     )
 
 
+class FormDto(BaseModel):
+    """フォームDTO"""
+    title: Optional[str] = Field(None, description="タイトル", example="家の近くに落書き")
+    category: Optional[Literal["対応依頼", "質問", "賞賛"]] = Field(None, description="カテゴリ")
+    description: Optional[str] = Field(None, description="詳細説明", example="家の近くにスプレーででっかい絵がたくさんあって目障り")
+    place: Optional[str] = Field(None, description="場所名", example="東京都大田区")
+
+
 class ChatRequest(BaseModel):
     """チャット形式の会話リクエスト"""
     mail_address: str = "test@example.com"
@@ -30,8 +38,12 @@ class ChatRequest(BaseModel):
         example=[
             {"role": "user", "content": "こんにちは"},
             {"role": "assistant", "content": "こんにちは！何かお手伝いできることはありますか？"},
-            {"role": "user", "content": "日本の首都はどこですか？"}
+            {"role": "user", "content": "東京都の中央区に住んでるんだけど、中央区の１番街のセブンイレブンの横の道路のど真ん中に大きな落書きがあって困ってるんだよねぇ"}
         ]
+    )
+    form: Optional[FormDto] = Field(
+        None,
+        description="現在のフォーム状態（部分的に埋まっている可能性あり）"
     )
     schema: Optional[dict] = Field(
         None,
@@ -51,5 +63,6 @@ class ChatResponse(BaseModel):
     success: bool = Field(..., description="処理の成功/失敗")
     generated_text: Optional[str] = Field(None, description="AIの返答")
     generated_json: Optional[dict] = None
+    form: Optional[FormDto] = Field(None, description="更新されたフォーム状態")
+    form_complete: bool = Field(False, description="フォームが完成したかどうか")
     error: Optional[str] = Field(None, description="エラーメッセージ（失敗時のみ）")
-

--- a/aws_sam/template.yaml
+++ b/aws_sam/template.yaml
@@ -1,0 +1,36 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+
+Description: FastAPI (existing) on Lambda
+
+Globals:
+  Function:
+    Runtime: python3.11
+    MemorySize: 512
+    Timeout: 30
+
+Resources:
+  UserChatAIAPI:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../ # ルート全部をパッケージ
+      Handler: aws_sam/handler.lambda_handler
+      Architectures: [x86_64]
+      Environment:
+        Variables:
+          BEDROCK_REGION: us-east-1
+      Policies:
+        - Statement:
+            - Effect: Allow
+              Action:
+                - bedrock:InvokeModel
+                - bedrock:InvokeModelWithResponseStream
+              Resource:
+                - "arn:aws:bedrock:ap-northeast-1::foundation-model/anthropic.claude-3-haiku-20240307-v1:0"
+                - "arn:aws:bedrock:*::foundation-model/*"
+      Events:
+        HttpProxy:
+          Type: HttpApi
+          Properties:
+            Path: /{proxy+}
+            Method: ANY


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - チャットでフォーム入力（タイトル・カテゴリ・説明・場所）に対応。段階的に不足項目を案内し、完了判定を返します。
  - フォーム完了時、場所から位置情報を自動取得して登録します。
  - 応答に現在のフォーム状態と完了フラグを含めます。

- API 変更
  - リクエストでフォームを受け付け、レスポンスでフォームと完了フラグを返却。既存クライアントは更新が必要な場合があります。

- Chores
  - AWS SAM テンプレートを追加し、HttpApi + Lambda でのデプロイをサポート。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->